### PR TITLE
Support trailing path for PHP files (PATH_INFO)

### DIFF
--- a/templates/nginx/common/wpcommon-noauth.conf
+++ b/templates/nginx/common/wpcommon-noauth.conf
@@ -4,12 +4,12 @@
 # Limit access to avoid brute force attack
 # https://baraktawily.blogspot.com/2018/02/how-to-dos-29-of-world-wide-websites.html
 location /wp-admin {
-	location ~ /wp-admin/admin-ajax.php$ {
+	location ~ /wp-admin/admin-ajax.php(/|$) {
 		limit_req zone=wp burst=8 nodelay;
 		include fastcgi_params;
 		fastcgi_pass php;
 	}
-	location ~* /wp-admin/.*\.php$ {
+	location ~ [^/]\.php(/|$) {
 		limit_req zone=wp burst=15 nodelay;
 		include fastcgi_params;
 		fastcgi_pass php;
@@ -35,7 +35,7 @@ location = /wp-config.txt {
 
 # Disallow php in upload folder
 location /wp-content/uploads/ {
-	location ~ \.php$ {
+	location ~ [^/]\.php(/|$) {
 		#Prevent Direct Access Of PHP Files From Web Browsers
 		deny all;
 	}

--- a/templates/nginx/common/wpcommon.conf
+++ b/templates/nginx/common/wpcommon.conf
@@ -4,12 +4,12 @@
 # Limit access to avoid brute force attack
 # https://baraktawily.blogspot.com/2018/02/how-to-dos-29-of-world-wide-websites.html
 location /wp-admin {
-	location ~ /wp-admin/admin-ajax.php$ {
+	location ~ /wp-admin/admin-ajax.php(/|$) {
 		limit_req zone=wp burst=8 nodelay;
 		include fastcgi_params;
 		fastcgi_pass php;
 	}
-	location ~* /wp-admin/.*\.php$ {
+	location ~ [^/]\.php(/|$) {
 		limit_req zone=wp burst=15 nodelay;
 		include common/acl.conf;
 		include fastcgi_params;
@@ -37,7 +37,7 @@ location = /wp-config.txt {
 
 # Disallow php in upload folder
 location /wp-content/uploads/ {
-	location ~ \.php$ {
+	location ~ [^/]\.php(/|$) {
 		#Prevent Direct Access Of PHP Files From Web Browsers
 		deny all;
 	}

--- a/templates/nginx/common/wpfc.conf
+++ b/templates/nginx/common/wpfc.conf
@@ -24,8 +24,11 @@ if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no
 location / {
 	try_files $uri $uri/ /index.php?$args;
 }
-location ~ \.php$ {
-	try_files $uri =404;
+location ~ [^/]\.php(/|$) {
+	fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+	if (!-f $document_root$fastcgi_script_name) {
+		return 404;
+	}
 	include fastcgi_params;
 	fastcgi_pass php;
 	fastcgi_cache_bypass $skip_cache;


### PR DESCRIPTION
Hi @QROkes,

I believe you've been contacted by a user of your script regarding the support of trailing pathname information (`PATH_INFO`) in PHP.  For example:

`/my-script.php/something-here`

The issue is that URLs like these don't work (they lead to a 404), while they are supported by all common webserver configurations, including Nginx's suggested set-up.

My WordPress plugin [PhastPress](https://wordpress.org/plugins/phastpress/) uses this feature to dynamically load resources without having to rely on query strings (`/parameters` instead of `/...`).  Although the feature is optional, it's nice to be able to use it with Webinoly.

I've tested these configuration changes on the user's web server configuration, which uses the latest Webinoly templates, and they work as intended.  I'd be happy if you could merge this PR in your next release.  :)

Let me know if you have any concerns or questions.

See: https://www.nginx.com/resources/wiki/start/topics/examples/phpfcgi/#connecting-nginx-to-php-fpm