### PR TITLE
Add -one-file-system and -progress options to backup commands

### DIFF
--- a/lib/bkp
+++ b/lib/bkp
@@ -817,8 +817,10 @@ export_site() {
 	fi
 	[[ -f /var/www/webinoly.conf_temp ]] && local include="$include /var/www/webinoly.conf_temp"
 	[[ $rp_upstream == "true" && -f /etc/nginx/conf.d/upstream_proxy.conf ]] && local include="$include /etc/nginx/conf.d/upstream_proxy.conf"
-	
-	[[ -n $include ]] && sudo tar -Pcf $destination/$filename $include
+	[[ -n $one_file_system ]] && local archive_args="--one-file-system"
+	[[ -n $progress ]] && local archive_args="$archive_args --verbose"
+
+	[[ -n $include ]] && sudo tar $archive_args -Pcf $destination/$filename $include
 	
 	# Remove temporary files
 	sudo rm -rf /var/www/webinoly_backup_db

--- a/lib/bkp
+++ b/lib/bkp
@@ -241,7 +241,13 @@ bkp_s3_profile() {
 	
 	if [[ -n $run ]]; then
 		check_duply_profile
-		sudo duply $profile backup_verify_purge --force --allow-source-mismatch
+		if [[ -n $one_file_system ]]; then
+			local archive_args="--exclude-other-filesystems"
+		fi
+		if [[ -n $progress ]]; then
+			local archive_args="$archive_args --progress"
+		fi
+		sudo duply $profile backup_verify_purge --force --allow-source-mismatch $archive_args
 		
 	elif [[ -n $info ]]; then
 		check_duply_profile
@@ -661,8 +667,11 @@ export_server() {
 	[[ -f $MYSQL_CONF_PATH/${MYSQL_CONF_PREF}-webinoly-login.cnf ]] && local include="$include $MYSQL_CONF_PATH/${MYSQL_CONF_PREF}-webinoly.cnf"
 	[[ -f $MYSQL_CONF_PATH/${MYSQL_CONF_PREF}-webinoly.cnf ]] && local include="$include $MYSQL_CONF_PATH/${MYSQL_CONF_PREF}-webinoly.cnf"
 	[[ -d /etc/nginx/certs ]] && local include="$include /etc/nginx/certs"
+	[[ -n $one_file_system ]] && local archive_args="--one-file-system"
+	[[ -n $progress ]] && local archive_args="$archive_args --verbose"
 	
-	sudo tar $exclude -Pcf $destination/$filename $include
+	echo $archive_args
+	sudo tar $exclude $archive_args -Pcf $destination/$filename $include
 
 	
 	# Remove Temporary Files

--- a/lib/sites
+++ b/lib/sites
@@ -1674,6 +1674,13 @@ cloning_site() {
 	else
 		echo "${blu}Cloning your site! ${dim} Wait...${end}"
 	fi
+
+	if [[ -n $one_file_system ]]; then
+		local archive_args="--one-file-system"
+	fi
+	if [[ -n $progress ]]; then
+		local archive_args="$archive_args --verbose"
+	fi
 	
 	if [[ -n $subfolder ]]; then
 		local subtype=$(is_subfolder $clone_from $subfolder)
@@ -1720,10 +1727,10 @@ cloning_site() {
 		if [[ -d /var/www/$clone_from/htdocs$subfolder ]]; then
 			local dest=$( echo $subfolder | rev | cut -f 2- -d "/" -s | rev )
 			sudo mkdir -p /var/www/$domain/htdocs$dest
-			sudo cp -r /var/www/$clone_from/htdocs$subfolder /var/www/$domain/htdocs$dest
+			sudo cp -r $archive_args /var/www/$clone_from/htdocs$subfolder /var/www/$domain/htdocs$dest
 		fi
 	else
-		[[ -d /var/www/$clone_from ]] && sudo cp -r /var/www/$clone_from /var/www/$domain
+		[[ -d /var/www/$clone_from ]] && sudo cp -r $archive_args /var/www/$clone_from /var/www/$domain
 	fi
 
 	[[ -d /var/www/$domain ]] && sudo chown -R www-data:www-data /var/www/$domain

--- a/usr/site
+++ b/usr/site
@@ -3,7 +3,7 @@
 # Site Manager Plugin (Create, delete and de/activate)
 # Syntax: site <domain> <option> <argument>
 # Options: -html, -php, -mysql, -wp, -parked, -proxy, -empty, -on, -off, -delete, -delete-all, -list, -cache, -ssl, -force-redirect, -multisite-convert, -clone-from, -replace-content, -redirection, -forward, -info, -env
-# Arguments: -cache, -root, -root-path, -subdomain, -ignore-ssl, -wildcard, -raw, -external-db, -revoke, -ssl-crt, -ssl-key, -ssl-ocsp, -subfolder, -from, -to, -http-code, -regex, -manual, -overwrite, -wp-cache-plugins, -dedicated-reverse-proxy, -must-staple, -cache-valid, -skip-cache, -skip-cookie-cache, -query-string-cache, -query-string-never-cache, -query-string-cache-default, -reset, -test-cert, -db-role, -domain-mapping-wp-id
+# Arguments: -cache, -root, -root-path, -subdomain, -ignore-ssl, -wildcard, -raw, -external-db, -revoke, -ssl-crt, -ssl-key, -ssl-ocsp, -subfolder, -from, -to, -http-code, -regex, -manual, -overwrite, -wp-cache-plugins, -dedicated-reverse-proxy, -must-staple, -cache-valid, -skip-cache, -skip-cookie-cache, -query-string-cache, -query-string-never-cache, -query-string-cache-default, -reset, -test-cert, -db-role, -domain-mapping-wp-id, -one-file-system, -progress
 
 # shopt is necessary for this kind !(html|<toolsport>) of patterns
 shopt -s extglob

--- a/usr/webinoly
+++ b/usr/webinoly
@@ -3,7 +3,7 @@
 # Webinoly Server Manager Plugin
 # Syntax: webinoly <option> <argument>
 # Options: -update, -server-reset, -verify, -dbpass, -tools-port, -login-www-data, -cache-valid, -uninstall, -info, -external-sources-update, -clear-cache, -version, -blockip, -dynvar, -default-site, -tools-site, -mysql-password, -smtp, -backup, -aws-s3-credentials, -db-import, -send-to-s3, -custom-headers, -skip-cache, -skip-cookie-cache, -query-string-cache, -query-string-never-cache, -email, -export, -import, -mysql-public-access
-# Arguments: -raw, -profile, -list, -bucket, -source, -delete, -run, -restore, -wp, -destination, -date, -s3-european-buckets, info, -file, -add-db-pre, -no-recovery, -recalculate, -dbname, -skip-db, -filename, -overwrite, -value
+# Arguments: -raw, -profile, -list, -bucket, -source, -delete, -run, -restore, -wp, -destination, -date, -s3-european-buckets, info, -file, -add-db-pre, -no-recovery, -recalculate, -dbname, -skip-db, -filename, -overwrite, -value, -one-file-system, -progress
 
 source /opt/webinoly/lib/webin
 source /opt/webinoly/lib/datadog


### PR DESCRIPTION
We were finding that when doing backups, we wanted an option to skip folders that are mount points for other file systems.  We also wanted to be able to get more feedback that the backup was progressing.  The two options `-one-file-system` and `-progress` meet these needs, respectively.  We have implemented them here for both local and duply-mediated backups.